### PR TITLE
feat: add modules for contract extensibility

### DIFF
--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,4 +1,13 @@
-import { StateInterface, ActionInterface, VoteInterface, BalancesInterface, InputInterface, VaultInterface, VaultParamsInterface } from "./faces";
+import {
+  StateInterface,
+  ActionInterface,
+  VoteInterface,
+  BalancesInterface,
+  InputInterface,
+  VaultInterface,
+  VaultParamsInterface,
+  ModuleInterface
+} from "./faces";
 
 declare const ContractError: any;
 declare const SmartWeave: any;
@@ -10,6 +19,11 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
   const votes: VoteInterface[] = state.votes;
   const input: InputInterface = action.input;
   const caller: string = action.caller;
+  const modules: ModuleInterface[] = state.modules;
+
+  for (let mod of modules) {
+    state = mod.call({state, action});
+  }
 
   /** Transfer Function */
   if (input.function === 'transfer') {
@@ -53,7 +67,7 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
   /** Balance Function */
   if (input.function === 'balance') {
     const target = input.target || caller;
-    
+
     if (typeof target !== 'string') {
       throw new ContractError('Must specificy target to get balance for.');
     }
@@ -84,7 +98,7 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
     }
 
     let balance = balances[target];
-    
+
     return { result: { target, balance } };
   }
 
@@ -169,7 +183,7 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
           } else {
             balances[caller] = locked.balance;
           }
-          
+
           vault[caller].splice(i, 1);
         }
       }
@@ -207,7 +221,7 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
     if(!(caller in vault)) {
       throw new ContractError('Caller needs to have locked balances.');
     }
-    
+
     const hasBalance = (vault[caller] && !!vault[caller].filter(a => a.balance > 0).length);
     if(!hasBalance) {
       throw new ContractError('Caller doesn\'t have any locked balance.');
@@ -270,7 +284,7 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
 
         lockLength = { lockLength: input.lockLength };
       }
-      
+
       Object.assign(vote, {
         recipient,
         qty: qty,
@@ -335,7 +349,7 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
           'value': input.value
         });
       }
-      
+
       votes.push(vote);
     } else if (voteType === 'indicative') {
       votes.push(vote);

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -21,6 +21,9 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
   const caller: string = action.caller;
   const modules: ModuleInterface[] = state.modules;
 
+  // Sort modules by ascending order of priotity weight, before calling them.
+  modules.sort((modA, modB) => modB.priorityWeight - modA.priorityWeight);
+
   for (let mod of modules) {
     state = mod.call({state, action});
   }

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -21,13 +21,6 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
   const input: InputInterface = action.input;
   const caller: string = action.caller;
 
-  // Sort extensions by ascending order of priority weight, before calling them.
-  extensions.sort((modA, modB) => modB.priorityWeight - modA.priorityWeight);
-
-  for (let extension of extensions) {
-    state = extension.call({state, action});
-  }
-
   /** Transfer Function */
   if (input.function === 'transfer') {
     const target = input.target;
@@ -520,6 +513,13 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
     extensions.push(extension);
 
     return { state };
+  }
+
+  // Sort extensions by ascending order of priority weight, before calling them.
+  extensions.sort((modA, modB) => modB.priorityWeight - modA.priorityWeight);
+
+  for (let extension of extensions) {
+    state = extension.call({state, action});
   }
 
   throw new ContractError(`No function supplied or function not recognised: "${input.function}"`);

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -6,7 +6,7 @@ import {
   InputInterface,
   VaultInterface,
   VaultParamsInterface,
-  ModuleInterface
+  ExtensionInterface
 } from "./faces";
 
 declare const ContractError: any;
@@ -17,15 +17,15 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
   const balances: BalancesInterface = state.balances;
   const vault: VaultInterface = state.vault;
   const votes: VoteInterface[] = state.votes;
+  const extensions: ExtensionInterface[] = state.extensions;
   const input: InputInterface = action.input;
   const caller: string = action.caller;
-  const modules: ModuleInterface[] = state.modules;
 
-  // Sort modules by ascending order of priotity weight, before calling them.
-  modules.sort((modA, modB) => modB.priorityWeight - modA.priorityWeight);
+  // Sort extensions by ascending order of priority weight, before calling them.
+  extensions.sort((modA, modB) => modB.priorityWeight - modA.priorityWeight);
 
-  for (let mod of modules) {
-    state = mod.call({state, action});
+  for (let extension of extensions) {
+    state = extension.call({state, action});
   }
 
   /** Transfer Function */
@@ -512,6 +512,14 @@ export function handle(state: StateInterface, action: ActionInterface): { state:
     }
 
     return { result: { target, role } };
+  }
+
+  if (input.function === 'extend') {
+    const extension = input.extension;
+
+    extensions.push(extension);
+
+    return { state };
   }
 
   throw new ContractError(`No function supplied or function not recognised: "${input.function}"`);

--- a/src/faces.ts
+++ b/src/faces.ts
@@ -6,7 +6,7 @@ export interface StateInterface {
   votes: VoteInterface[];
   roles: RoleInterface;
   settings: [string, any][];
-  modules: ModuleInterface[];
+  extensions: ExtensionInterface[];
 }
 
 export interface RoleInterface {
@@ -32,7 +32,9 @@ export interface ActionInterface {
   caller: string;
 }
 
-export interface ModuleInterface {
+// Allows the developer to extend the contract in any custom way, by passing
+// state and action to a given `call` method.
+export interface ExtensionInterface {
   // Ideally, a unique, meaningful id for the module.
   id: string;
   // Priority weight of this module against other modules when running sequentially.
@@ -41,7 +43,12 @@ export interface ModuleInterface {
   call({state: StateInterface, action: ActionInterface}): StateInterface;
 }
 
-export interface InputInterface extends VoteInterface {
+// Allows the contract to call `extend` and provide an extension.
+export interface ExtendInterface {
+  extension?: ExtensionInterface;
+}
+
+export interface InputInterface extends VoteInterface, ExtendInterface {
   function: GetFunctionType | SetFunctionType;
   cast?: string;
 }
@@ -73,4 +80,4 @@ export interface ResultInterface {
 export type VoteStatus = 'active' | 'quorumFailed' | 'passed' | 'failed';
 export type VoteType = 'mint' | 'mintLocked' | 'burnVault' | 'indicative' | 'set';
 export type GetFunctionType = 'balance' | 'unlockedBalance' | 'vaultBalance' | 'role';
-export type SetFunctionType = 'transfer' | 'vote' | 'propose' | 'finalize' | 'lock' | 'increaseVault' | 'unlock';
+export type SetFunctionType = 'transfer' | 'vote' | 'propose' | 'finalize' | 'lock' | 'increaseVault' | 'unlock' | 'extend';

--- a/src/faces.ts
+++ b/src/faces.ts
@@ -33,6 +33,11 @@ export interface ActionInterface {
 }
 
 export interface ModuleInterface {
+  // Ideally, a unique, meaningful id for the module.
+  id: string;
+  // Priority weight of this module against other modules when running sequentially.
+  priorityWeight?: number;
+  // A function that runs whenever the contract is handled.
   call({state: StateInterface, action: ActionInterface}): StateInterface;
 }
 

--- a/src/faces.ts
+++ b/src/faces.ts
@@ -6,6 +6,7 @@ export interface StateInterface {
   votes: VoteInterface[];
   roles: RoleInterface;
   settings: [string, any][];
+  modules: ModuleInterface[];
 }
 
 export interface RoleInterface {
@@ -29,6 +30,10 @@ export interface VaultParamsInterface {
 export interface ActionInterface {
   input: InputInterface;
   caller: string;
+}
+
+export interface ModuleInterface {
+  call({state: StateInterface, action: ActionInterface}): StateInterface;
 }
 
 export interface InputInterface extends VoteInterface {


### PR DESCRIPTION
The goal here is to be able to extend contracts to allow for any functionality to be added by the developer.

Changes:
* Add an interface for extensions (module is reserved)
* Allow extensions to be added to the contract via an `extend` action
* Iterates through extensions at the end of the handle function